### PR TITLE
fix: 전체 일기 목록 기능 구현 및 일기 목록 관련 기능 수정

### DIFF
--- a/src/main/java/com/beyond/meongnyang/post/controller/PostRestController.java
+++ b/src/main/java/com/beyond/meongnyang/post/controller/PostRestController.java
@@ -70,17 +70,30 @@ public class PostRestController {
         );
     }
 
-    // 일기 목록 조회
+    // 전체 일기 목록 조회
     @GetMapping
-    public ResponseEntity<?> posts(@PageableDefault(value = 9, sort = "id", direction = Sort.Direction.DESC) Pageable pageable, @RequestParam(required = false, value = "userId") Long userId) {
+    public ResponseEntity<?> posts(@PageableDefault(value = 9, sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
         return new ResponseEntity<>(
                 CommonRes.ofSuccess(
-                        postService.posts(pageable, userId),
+                        postService.allPosts(pageable),
+                        HttpStatus.OK.value(),
+                        "일기 목록을 불러왔습니다."
+                ), HttpStatus.OK
+        );
+    }
+
+    // 내 일기 목록 조회
+    @GetMapping("/me")
+    public ResponseEntity<?> myPosts(@PageableDefault(value = 9, sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
+        return new ResponseEntity<>(
+                CommonRes.ofSuccess(
+                        postService.posts(pageable, null),
                         HttpStatus.OK.value(),
                         "내 일기 목록을 불러왔습니다."
                 ), HttpStatus.OK
         );
     }
+
     // 일기 상세 조회
     @GetMapping("/{id}")
     public ResponseEntity<?> postDetail(@PathVariable("id") Long postId) {
@@ -199,8 +212,6 @@ public class PostRestController {
                 ), HttpStatus.OK
         );
     }
-
-    // 친구 추천
 
     // 검색
     @GetMapping("/search")

--- a/src/main/java/com/beyond/meongnyang/post/repository/PostRepository.java
+++ b/src/main/java/com/beyond/meongnyang/post/repository/PostRepository.java
@@ -14,4 +14,5 @@ import java.util.Optional;
 @Repository
 public interface PostRepository extends JpaRepository<Post, Long>, JpaSpecificationExecutor<Post> {
     Page<Post> findAllByUserId(Long userId, Pageable pageable);
+    Page<Post> findAllByDelYnFalse(Pageable pageable);
 }

--- a/src/main/java/com/beyond/meongnyang/post/service/PostService.java
+++ b/src/main/java/com/beyond/meongnyang/post/service/PostService.java
@@ -90,7 +90,20 @@ public class PostService {
         post.deletePost("Y");
     }
 
-    // 일기 목록 조회
+    // 전체 일기 목록 조회
+    public Page<PostDetailRes> allPosts(Pageable pageable) {
+        Page<Post> posts = postRepository.findAllByDelYnFalse(pageable);
+
+        return posts.map(post -> {
+            Pet pet = petRepository
+                    .findByUserIdAndFirstPetAndDelYn(post.getUser().getId(), true, "N")
+                    .orElseThrow(() -> new EntityNotFoundException("해당 펫이 존재하지 않습니다."));
+            int likeCount = likeRepository.countByPostId(post.getId());
+            return PostDetailRes.fromEntity(post, pet, likeCount);
+        });
+    }
+
+    // 내 일기 목록 조회
     public Page<PostListReq> posts(Pageable pageable, Long userId) {
         User user;
         if(userId != null){
@@ -99,8 +112,9 @@ public class PostService {
             user = commonService.getCurrentUser();
         }
         Page<Post> postList = postRepository.findAllByUserId(user.getId(), pageable);
-        return postList.map(p -> PostListReq.fromEntity(p));
+        return postList.map(PostListReq::fromEntity);
     }
+
     // 일기 상세 조회
     public PostDetailRes findByPostId(Long postId) {
         Post post = postRepository.findById(postId).orElseThrow(() -> new EntityNotFoundException("해당 일기가 존재하지 않습니다"));

--- a/src/main/java/com/beyond/meongnyang/user/controller/UserRestController.java
+++ b/src/main/java/com/beyond/meongnyang/user/controller/UserRestController.java
@@ -2,6 +2,7 @@ package com.beyond.meongnyang.user.controller;
 
 import com.beyond.meongnyang.common.dto.CommonRes;
 import com.beyond.meongnyang.common.security.JwtTokenProvider;
+import com.beyond.meongnyang.post.service.PostService;
 import com.beyond.meongnyang.user.dto.check.*;
 import com.beyond.meongnyang.user.dto.oauth2.*;
 import com.beyond.meongnyang.user.entity.SocialType;
@@ -41,6 +42,7 @@ public class UserRestController {
     private final JwtTokenProvider jwtTokenProvider;
     private final GoogleLoginService googleLoginService;
     private final KakaoLoginService kakaoLoginService;
+    private final PostService postService;
 
     // 헤더로 rt 응답 공통부분
     private ResponseEntity<?> okWithRtHeader(Object body, String refreshToken) {
@@ -353,6 +355,7 @@ public class UserRestController {
         return new ResponseEntity<>(CommonRes.ofSuccess("언팔로우 완료", HttpStatus.OK.value(), "언팔로우를 성공했습니다."), HttpStatus.OK);
     }
 
+    // 팔로우 상태 조회
     @GetMapping("/follows/{id}/status")
     public ResponseEntity<?> checkFollowStatus(@PathVariable("id") Long followingId) {
         boolean isFollowing = userService.checkFollowStatus(followingId);
@@ -375,7 +378,6 @@ public class UserRestController {
                 HttpStatus.OK
         );
     }
-
 
     // 팔로잉 목록 조회
     @GetMapping("/follows/followings")
@@ -407,5 +409,17 @@ public class UserRestController {
     @GetMapping("/blocks")
     public ResponseEntity<?> blockList(@PageableDefault(value = 9, sort = "id", direction = Sort.Direction.DESC) Pageable pageable, @RequestParam("type") String name){
         return new ResponseEntity<>(CommonRes.ofSuccess(userService.blockUsers(name, pageable), HttpStatus.OK.value(), "차단 목록을 조회했습니다."), HttpStatus.OK);
+    }
+
+    // 사용자 일기 목록 조회
+    @GetMapping("/{id}/posts")
+    public ResponseEntity<?> userPostList(@PageableDefault(value = 9, sort = "id", direction = Sort.Direction.DESC) Pageable pageable, @PathVariable("id") Long id) {
+        return new ResponseEntity<>(
+                CommonRes.ofSuccess(
+                        postService.posts(pageable, id),
+                        HttpStatus.OK.value(),
+                        "일기 목록을 불러왔습니다."
+                ), HttpStatus.OK
+        );
     }
 }


### PR DESCRIPTION
## :sparkles: 작업 내용
- 전체 일기 목록 조회 기능 구현
- 일기 목록 세분화(전체, 내 일기 목록, 특정 사용자 일기 목록)
## :wrench: 주요 변경 사항
01.  다음 기능을 구현
-전체 일기 목록 조회 -> id값을 기준으로 1페이지당 9개 일기 오름차순 정렬(최근 글이 먼저 보이게끔), 삭제되지 않은 모든 사용자의 글을 불러옴
02. 다음 부분을 수정
- 일기 목록 세분화 작업 진행
- 전체 일기 목록(/posts) ```GET```
- 내 일기 목록 (/posts/me)```GET```
- 특정 사용자 일기 목록 (/users/{id}/posts)```GET```