### PR TITLE
locked user 디비 변경 후 이멜 발송되게 처리

### DIFF
--- a/src/main/java/com/beyond/meongnyang/common/event/TempPasswordAfterCommitListener.java
+++ b/src/main/java/com/beyond/meongnyang/common/event/TempPasswordAfterCommitListener.java
@@ -1,0 +1,21 @@
+package com.beyond.meongnyang.common.event;
+
+import com.beyond.meongnyang.user.service.SendEmailService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class TempPasswordAfterCommitListener {
+
+    private final SendEmailService sendEmailService;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void on(TempPasswordIssuedEvent e) {
+        // 트랜잭션 커밋 이후에만 호출됨
+        System.out.println("[DEBUG] AFTER_COMMIT fired for " + e.to());
+        sendEmailService.sendTemporaryPassword(e.to(), e.tempPassword());
+    }
+}

--- a/src/main/java/com/beyond/meongnyang/common/event/TempPasswordIssuedEvent.java
+++ b/src/main/java/com/beyond/meongnyang/common/event/TempPasswordIssuedEvent.java
@@ -1,0 +1,7 @@
+package com.beyond.meongnyang.common.event;
+
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+public record TempPasswordIssuedEvent(String to, String tempPassword) {
+}

--- a/src/main/java/com/beyond/meongnyang/user/entity/User.java
+++ b/src/main/java/com/beyond/meongnyang/user/entity/User.java
@@ -129,6 +129,7 @@ public class User extends CommonAt {
     // 잠금 해제
     public void unlockedAccount() {
         this.isLocked = "N";
+        this.isLockedAt = null;
     }
 
     // 비밀번호 변경

--- a/src/main/java/com/beyond/meongnyang/user/service/SendEmailService.java
+++ b/src/main/java/com/beyond/meongnyang/user/service/SendEmailService.java
@@ -1,6 +1,8 @@
 package com.beyond.meongnyang.user.service;
 
+import com.beyond.meongnyang.common.event.TempPasswordIssuedEvent;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Service;
@@ -8,9 +10,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-@Transactional
 public class SendEmailService {
     private final JavaMailSender mailSender;
+    private final ApplicationEventPublisher events;
 
     public void sendTemporaryPassword(String emailTO, String tempPassword) {
         SimpleMailMessage message = new SimpleMailMessage();
@@ -19,6 +21,10 @@ public class SendEmailService {
         message.setText("요청하신 임시 비밀번호는 다음과 같습니다.\n\n"
                 + tempPassword + "\n\n로그인 후 꼭 비밀번호를 변경해주세요.");
         mailSender.send(message);
+    }
+    // 커밋 후 발송 예약 (유저 서비스 로직에서 이걸 호출)
+    public void queueTemporaryPassword(String emailTO, String tempPassword) {
+        events.publishEvent(new TempPasswordIssuedEvent(emailTO, tempPassword));
     }
 
     public void sendVerificationCode(String emailTO , String code) {

--- a/src/main/java/com/beyond/meongnyang/user/service/UserService.java
+++ b/src/main/java/com/beyond/meongnyang/user/service/UserService.java
@@ -191,11 +191,17 @@ public class UserService {
         if(user.getDelYn().equals("Y")) {
             throw new IllegalArgumentException("이미 탈퇴한 계정입니다.");
         }
-        userLockedService.resetFailedCount(user.getId());
-        user.unlockedAccount();
-        String tempPassword = userLockedService.generateTempPassword();
-        user.updatePassword(passwordEncoder.encode(tempPassword));
-        sendEmailService.sendTemporaryPassword(req.getEmail(), tempPassword);
+        user.updateCount(0);                                            // 실패시도 직접 초기화
+        user.unlockedAccount();                                         // 잠금 처리 초기화
+        String tempPassword = userLockedService.generateTempPassword(); // 임시비밀번호 발급
+        user.updatePassword(passwordEncoder.encode(tempPassword));      // 임시비밀번호 암호화
+
+        userRepository.saveAndFlush(user);
+
+        // 커밋 후 메일 발송 예약
+        System.out.println("[DEBUG] queuing mail for " + user.getEmail());
+        sendEmailService.queueTemporaryPassword(user.getEmail(), tempPassword);
+        // 메서드 종료 시 트랜잭션 커밋 → 그 다음 리스너가 발송
 
     }
 


### PR DESCRIPTION
변경 전 에러는 동시성으로 인한 읽기-쓰기 불일치가 원인.
지금은 멱등 UPDATE + 트랜잭션/이벤트 정리로 동시성 충돌 면역이 생겼고, 프론트도 정상 동작